### PR TITLE
Renamed deprecated celeryd to celery worker.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,11 +60,11 @@ The hard but safe way
 4. Save the script to ``/etc/init.d/mediagoblin-paster`` (without the ``.sh``
    file extension)
 5. Run ``sudo insserv mediagoblin-paster``.
-6. *Repeat all steps again, but with mediagoblin-celeryd.*
+6. *Repeat all steps again, but with mediagoblin-celery-worker.*
 
 Now, to start the services, simply run 
 ``sudo service mediagoblin-paster start`` and
-``sudo service mediagoblin-celeryd start``.
+``sudo service mediagoblin-celery-worker start``.
 
 License
 -------

--- a/installer.sh
+++ b/installer.sh
@@ -39,8 +39,8 @@ PASTER_INIT_URL="http://wandborg.se/mediagoblin-init-scripts/mediagoblin-paster.
 
 PASTER_INIT_DESTINATION=/etc/init.d/mediagoblin-paster
 
-CELERYD_INIT_URL="http://wandborg.se/mediagoblin-init-scripts/mediagoblin-celeryd.sh"
-CELERYD_INIT_DESTINATION=/etc/init.d/mediagoblin-celeryd
+CELERYD_INIT_URL="http://wandborg.se/mediagoblin-init-scripts/mediagoblin-celery-worker.sh"
+CELERYD_INIT_DESTINATION=/etc/init.d/mediagoblin-celery-worker
 
 verify_and_install () {
     INIT_PATH=$1
@@ -67,7 +67,7 @@ sudo su -c "curl $PASTER_INIT_URL \
 
 verify_and_install $PASTER_INIT_DESTINATION
 
-# Download and fix the mediagoblin-celeryd script
+# Download and fix the mediagoblin-celery-worker script
 sudo su -c "curl $CELERYD_INIT_URL \
     | sed s,^MG_ROOT=.*\n,MG_ROOT=$MEDIAGOBLIN_ROOT, \
     | sed s,^MG_USER=.*\n,MG_USER=$MEDIAGOBLIN_USER, \

--- a/mediagoblin-celery-worker.sh
+++ b/mediagoblin-celery-worker.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# /etc/init.d/mediagoblin-celeryd
+# /etc/init.d/mediagoblin-celery-worker
 #
 ## LICENSE: CC0 <http://creativecommons.org/publicdomain/zero/1.0/>
 # To the extent possible under law, Joar Wandborg <http://wandborg.se> has
 # waived all copyright and related or neighboring rights to
-# mediagoblin-celeryd. This work is published from Sweden.
+# mediagoblin-celery-worker. This work is published from Sweden.
 #
 ## CREDIT
 # Credit goes to jpope <http://jpope.org/> and 
@@ -12,7 +12,7 @@
 # based upon.
 #
 ### BEGIN INIT INFO
-# Provides:          mediagoblin-celeryd
+# Provides:          mediagoblin-celery-worker
 # Required-Start:    $network $named $local_fs
 # Required-Stop:     $remote_fs $syslog $network $named $local_fs
 # Should-Start:      postgres $syslog
@@ -36,10 +36,10 @@ MG_USER=mediagoblin
 
 set -e
 
-DAEMON_NAME=mediagoblin-celeryd
+DAEMON_NAME=mediagoblin-celery-worker
 
 MG_BIN=$MG_ROOT/bin
-MG_CELERYD_BIN=$MG_BIN/celeryd
+MG_CELERYD_BIN=$MG_BIN/celery\ worker
 MG_CONFIG=$MG_ROOT/mediagoblin_local.ini
 MG_CELERY_CONFIG_MODULE=mediagoblin.init.celery.from_celery
 MG_CELERYD_PID_FILE=/var/run/mediagoblin/$DAEMON_NAME.pid
@@ -108,7 +108,7 @@ getPID() {
 
 case "$1" in 
     start)
-        # Start the MediaGoblin celeryd process
+        # Start the MediaGoblin celery worker process
         log_daemon_msg "Starting GNU MediaGoblin Celery task queue" "$DAEMON_NAME"
         if [ -z "$(getPID)" ]; then
             # TODO: Could we send things to log a little bit more beautiful?


### PR DESCRIPTION
Running celeryd, the script stores this in mediagoblin-celeryd.pid :
`
("\nThe 'celeryd' command is deprecated, please use 'celery worker' instead:\n\n$ celery worker --pidfile=/var/run/mediagoblin/mediagoblin-celeryd.pid -f /var/log/mediagoblin/mediagoblin-celeryd.log\n\n",)
`
The proposed changes fix that issue.
